### PR TITLE
New class for the Maxbotix ultrasonic distance sensor

### DIFF
--- a/src/UltrasonicMaxbotix.cpp
+++ b/src/UltrasonicMaxbotix.cpp
@@ -1,0 +1,54 @@
+#include <UltrasonicMaxbotix.h>
+
+/// Create an instance of the Ultrasonic Maxbotix sensor.
+///
+/// See Ultrasonic class in the WPILib library for argument documentation
+UltrasonicMaxbotix::UltrasonicMaxbotix(DigitalOutput* pingChannel, DigitalInput* echoChannel, DistanceUnit units /* = kInches */)
+	: Ultrasonic(pingChannel, echoChannel, units)
+{
+}
+
+/// Create an instance of the Ultrasonic Maxbotix sensor.
+///
+/// See Ultrasonic class in the WPILib library for argument documentation
+UltrasonicMaxbotix::UltrasonicMaxbotix(DigitalOutput& pingChannel, DigitalInput& echoChannel, DistanceUnit units /* = kInches */)
+	: Ultrasonic(pingChannel, echoChannel, units)
+{
+}
+
+/// Create an instance of the Ultrasonic Maxbotix sensor.
+///
+/// See Ultrasonic class in the WPILib library for argument documentation
+UltrasonicMaxbotix::UltrasonicMaxbotix(std::shared_ptr<DigitalOutput> pingChannel,std::shared_ptr<DigitalInput> echoChannel, DistanceUnit units /* = kInches */)
+	: Ultrasonic(pingChannel, echoChannel, units)
+{
+}
+
+/// Create an instance of the Ultrasonic Maxbotix sensor.
+///
+/// See Ultrasonic class in the WPILib library for argument documentation
+UltrasonicMaxbotix::UltrasonicMaxbotix(int pingChannel, int echoChannel, DistanceUnit units /* = kInches */)
+	: Ultrasonic(pingChannel, echoChannel, units)
+{
+}
+
+UltrasonicMaxbotix::~UltrasonicMaxbotix()
+{
+}
+	
+/// Get the range in inches from the ultrasonic sensor
+///
+/// @return Range in inches to the target returned from the ultrasonic sensor
+double UltrasonicMaxbotix::GetRangeInches() const
+{
+	return Ultrasonic::GetRangeInches() * kValueToInches;
+
+}
+
+/// Get the range in millimeters from the ultrasonic sensor
+///
+/// @return Range in millimeters to the target returned from the ultrasonic sensor
+double UltrasonicMaxbotix::GetRangeMM() const
+{
+	return GetRangeInches() * 25.4;
+}

--- a/src/UltrasonicMaxbotix.h
+++ b/src/UltrasonicMaxbotix.h
@@ -1,0 +1,40 @@
+/*
+ * UltrasonicMaxbotix.h
+ *
+ *  Created on: Jan 23, 2018
+ *      Author: Developer
+ */
+
+#ifndef SRC_ULTRASONICMAXBOTIX_H_
+#define SRC_ULTRASONICMAXBOTIX_H_
+
+#include <Ultrasonic.h>
+
+/// Ultrasonic Maxbotix rangefinder MB1013
+///
+/// \detail The ultrasonic class was written for the Daventech SRF 04 which has a 5.8 us per mm
+/// The Maxbotix sensor has a 1 us per mm factor, so this class wraps the base and provides the correct scaling.
+class UltrasonicMaxbotix : public Ultrasonic
+{
+public:
+	~UltrasonicMaxbotix();
+
+	UltrasonicMaxbotix(DigitalOutput* pingChannel, DigitalInput* echoChannel,
+	             DistanceUnit units = kInches);
+	UltrasonicMaxbotix(DigitalOutput& pingChannel, DigitalInput& echoChannel,
+	             DistanceUnit units = kInches);
+	UltrasonicMaxbotix(std::shared_ptr<DigitalOutput> pingChannel,
+	             std::shared_ptr<DigitalInput> echoChannel,
+	             DistanceUnit units = kInches);
+	UltrasonicMaxbotix(int pingChannel, int echoChannel, DistanceUnit units = kInches);
+
+	double GetRangeInches() const;
+	double GetRangeMM() const;
+
+
+private:
+	static constexpr double kValueToInches = 6.35; //!< Emperically determined conversion factor
+};
+
+
+#endif /* SRC_ULTRASONICMAXBOTIX_H_ */


### PR DESCRIPTION
The WPI Ultrasonic class is geared to the Daventech SRF04 sensor, which
has a 5.8us/mm pulse output.  The Maxbotix sensor that came in the kit
of parts in 2018 has a 1us/mm pulse output.  This class derives from the
WPI Ultrasonic class but re-implements the GetRangeInches and GetRangeMM
functions to use the proper conversion factor.